### PR TITLE
Fix incorrect reference in 3-filesystem.md

### DIFF
--- a/src/3-filesystem.md
+++ b/src/3-filesystem.md
@@ -167,7 +167,7 @@ where Rust can't convert a line to UTF-8.  Fine for casual code, bad for product
 
 ## Writing To Files
 
-We met the `write!` macro when implementing `Display` - it also works with anything
+We met the `write!` macro when implementing `Debug` - it also works with anything
 that implements `Write`. So here's a another way of saying `print!`:
 
 ```rust


### PR DESCRIPTION
According to [this section](https://github.com/stevedonovan/gentle-intro/blob/master/src/2-structs-enums-lifetimes.md#traits), `write!` was used for implementing `Debug`, not `Display`. In fact, `Display` is not mentioned anywhere up until the fixed sentence.