### PR TITLE
Add missing language tag in object-orientation.md

### DIFF
--- a/src/object-orientation.md
+++ b/src/object-orientation.md
@@ -424,7 +424,7 @@ other methods.
 
 Things now proceed as before:
 
-```
+```rust
 #[derive(Debug)]
 struct Foo {
     name: String,


### PR DESCRIPTION
This enables syntax-highlighting for the code segment in question.