### PR TITLE
fix show_list box example

### DIFF
--- a/src/object-orientation.md
+++ b/src/object-orientation.md
@@ -86,7 +86,7 @@ go out of scope and `Drop` kicks in, then that memory is released.
 let answer = Box::new(42);
 let maybe_pi = Box::new(3.14);
 
-let show_list: Vec<Box<Show>> = vec![question,answer];
+let show_list: Vec<Box<Show>> = vec![answer,maybe_pi];
 for d in &show_list {
     println!("show {}",d.show());
 }

--- a/src/object-orientation.md
+++ b/src/object-orientation.md
@@ -122,6 +122,8 @@ let show_list: Vec<Box<Show>> = vec![answer,maybe_pi];
 for d in &show_list {
     println!("show {}",d.show());
 }
+// show four-byte signed 42
+// show eight-byte float 3.14
 ```
 
 The difference is that you can now take this vector, pass it as a

--- a/src/object-orientation.md
+++ b/src/object-orientation.md
@@ -56,6 +56,22 @@ impl Show for f64 {
 Here's a little program with big implications:
 
 ```rust
+# trait Show {
+#     fn show(&self) -> String;
+# }
+#
+# impl Show for i32 {
+#     fn show(&self) -> String {
+#         format!("four-byte signed {}", self)
+#     }
+# }
+#
+# impl Show for f64 {
+#     fn show(&self) -> String {
+#         format!("eight-byte float {}", self)
+#     }
+# }
+
 fn main() {
     let answer = 42;
     let maybe_pi = 3.14;
@@ -83,6 +99,22 @@ allocated on the heap, and acts very much like a reference - it's a _smart point
 go out of scope and `Drop` kicks in, then that memory is released.
 
 ```rust
+# trait Show {
+#     fn show(&self) -> String;
+# }
+#
+# impl Show for i32 {
+#     fn show(&self) -> String {
+#         format!("four-byte signed {}", self)
+#     }
+# }
+#
+# impl Show for f64 {
+#     fn show(&self) -> String {
+#         format!("eight-byte float {}", self)
+#     }
+# }
+
 let answer = Box::new(42);
 let maybe_pi = Box::new(3.14);
 


### PR DESCRIPTION
Fix variable reference (`question`) to match the defined variable (`maybe_pi`), and swapped the order to match the variable definition order and the prior example.

Q: Is there a way to include elided code in your markdown processor, like the `# prefix` lines in rustdoc?  It'd be nice to have all the necessary code to run the example in a single block, by including the trait definition block into this example.