### PR TITLE
Fix a minor typo in 5-stdlib-containers.md

### DIFF
--- a/src/5-stdlib-containers.md
+++ b/src/5-stdlib-containers.md
@@ -388,7 +388,7 @@ the stdlib) then such implemention would not be allowed. In this way, you are
 saved from creating confusion.
 
 Before congratulating ourselves on such a clever, convenient shortcut, you should be
-aware of the consequences. If `make_set` was written so, so that these are sets
+aware of the consequences. If `make_set` was written so that these are sets
 of owned strings, then the actual type of `intersect` could come as a surprise:
 
 ```rust


### PR DESCRIPTION
I think this is a minor typo -- I apologize if I am mistaken. Thank you for writing this document -- it is very helpful to me while learning Rust. 