### PR TITLE
extern crate is considered unidiomatic in 2018 rust

### DIFF
--- a/code/json-serde.rs
+++ b/code/json-serde.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Person {
+    name: String,
+    age: u8,
+    address: Address,
+    phones: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Address {
+    street: String,
+    city: String,
+}
+
+fn main() {
+    let data = r#" {
+     "name": "John Doe", "age": 43,
+     "address": {"street": "main", "city":"Downtown"},
+     "phones":["27726550023"]
+    } "#;
+    let p: Person = serde_json::from_str(data).expect("deserialize error");
+    println!("Please call {} at the number {}", p.name, p.phones[0]);
+
+    println!("{:#?}",p);
+}

--- a/code/mod4.rs
+++ b/code/mod4.rs
@@ -1,6 +1,4 @@
 // mod4.rs
-extern crate foo;
-
 fn main() {
     let f = foo::Foo::new("hello");
     println!("{:?}",f);    

--- a/code/test-json.rs
+++ b/code/test-json.rs
@@ -1,5 +1,5 @@
 // test-json/src/main.rs
-extern crate json;
+use json;
 
 fn main() {
     let mut doc = json::parse(r#"

--- a/src/4-modules.md
+++ b/src/4-modules.md
@@ -448,17 +448,14 @@ the `test-serde-json` directory, and edit `Cargo.toml`. Edit it like so:
 
 ```
 [dependencies]
-serde="0.9"
-serde_derive="0.9"
-serde_json="0.9"
+serde = { version = "1.0", features = ["derive"] }
+serde_json= " 1.0"
 ```
 
 And edit `src/main.rs` to be this:
 
 ```rust
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Person {
@@ -487,8 +484,9 @@ fn main() {
 }
 ```
 
-You have seen the `derive` attribute before, but the `serde_derive` crate defines _custom derives_
-for the special `Serialize` and `Deserialize` traits. And the result shows the generated Rust struct:
+You have seen the `derive` attribute before, but the `derive` feature on the serde crate defines
+_custom derives_ for the special `Serialize` and `Deserialize` traits. And the result shows the
+generated Rust struct:
 
 ```
 Please call John Doe at the number 27726550023

--- a/src/4-modules.md
+++ b/src/4-modules.md
@@ -341,7 +341,7 @@ and end up with ugliness:
 
 ```rust
 // test-json/src/main.rs
-extern crate json;
+use json;
 
 fn main() {
     let doc = json::parse(r#"
@@ -429,11 +429,11 @@ Here's a truly beautiful use of macros to generate _JSON literals_:
     );
 ```
 
-For this to work, you need to explicitly import macros from the JSON crate thus:
+For this to work, you need to import macros from the JSON crate thus:
 
 ```rust
-#[macro_use]
-extern crate json;
+use json;
+use json::{array, object};
 ```
 
 There is a downside to using this crate, because of the mismatch between the amorphous, dynamically-typed

--- a/src/4-modules.md
+++ b/src/4-modules.md
@@ -540,7 +540,6 @@ regular expression is "match exactly two digits, the character ':', and then any
 Capture both sets of digits":
 
 ```rust
-extern crate regex;
 use regex::Regex;
 
 let re = Regex::new(r"(\d{2}):(\d+)").unwrap();
@@ -585,7 +584,6 @@ For this, you need dedicated date-time processing, which is provided by [chrono]
 You need to decide on a time zone when doing dates:
 
 ```rust
-extern crate chrono;
 use chrono::*;
 
 fn main() {

--- a/src/4-modules.md
+++ b/src/4-modules.md
@@ -222,13 +222,13 @@ We can now _link_ this into our main program:
 ```
 src$ rustc mod4.rs --extern foo=libfoo.rlib
 ```
-But the main program must now look like this, where the `extern` name is the same
-as the one used when linking. There is an implicit top-level module `foo` associated
-with the library crate:
+Crates provided to the the compiler, as in `rustc` using `--extern`, are added to the
+"extern prelude". Crates in the "extern prelude" are in scope for the entire crate.
+Beginning in the 2018 edition, use declarations can reference crates in the extern prelude,
+so it is considered unidiomatic to use `extern crate`.
 
 ```
 // mod4.rs
-extern crate foo;
 
 fn main() {
     let f = foo::Foo::new("hello");

--- a/src/6-error-handling.md
+++ b/src/6-error-handling.md
@@ -159,12 +159,11 @@ a basic error type based on a string, as we have defined it here, and a few conv
 Like any error, it works fine with `Box<Error>`:
 
 ```rust
-#[macro_use]
-extern crate simple_error;
+use simple_error::bail;
 
 use std::error::Error;
 
-type BoxResult<T> = Result<T,Box<Error>>;
+type BoxResult<T> = Result<T,Box<dyn Error>>;
 
 fn run(s: &str) -> BoxResult<i32> {
     if s.len() == 0 {

--- a/src/7-shared-and-networking.md
+++ b/src/7-shared-and-networking.md
@@ -548,7 +548,6 @@ API. Here's the 'Hello, World!' - an iterator feeds us inputs and we execute up 
 on the values in parallel.
 
 ```rust
-extern crate pipeliner;
 use pipeliner::Pipeline;
 
 fn main() {
@@ -579,7 +578,6 @@ on the principle. We reuse the `shell` function defined in section 4 to call `pi
 of IP4 addresses.
 
 ```rust
-extern crate pipeliner;
 use pipeliner::Pipeline;
 
 use std::process::Command;
@@ -666,7 +664,6 @@ So, let's naively use this method to rewrite the pipeliner example. Most network
 address and a port:
 
 ```rust
-extern crate pipeliner;
 use pipeliner::Pipeline;
 
 use std::net::*;


### PR DESCRIPTION
Removes usage of `extern crate` where appropriate. There are still a few places where `extern crate` is the most reasonable solution due to crates which have not been updated to the current idioms (nom, error_chain).