### PR TITLE
2-structs-enums-...: fix compilation problems in struct4.rs

### DIFF
--- a/src/2-structs-enums-lifetimes.md
+++ b/src/2-structs-enums-lifetimes.md
@@ -390,7 +390,6 @@ Here is the final little program:
 
 ```rust
 // struct4.rs
-use std::fmt;
 
 #[derive(Debug)]
 struct Person {
@@ -426,6 +425,8 @@ fn main() {
     println!("{:?}", p);
 
     p.set_first_name("Jane");
+
+    println!("{}", p.full_name());
 
     println!("{:?}", p);
 


### PR DESCRIPTION
Looks like some last minute edit was not tested, I get these warnings when trying to compile struct4.rs without this patch:

```
warning: unused import: `std::fmt`
 --> hello.rs:1:5
  |
1 | use std::fmt;
  |     ^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: associated function is never used: `full_name`
  --> hello.rs:18:8
   |
18 |     fn full_name(&self) -> String {
   |        ^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: 2 warnings emitted
```

Thank you for writing and publishing the book, a great help for Rust newbies.
