### PR TITLE
Update deprecated inclusive range

### DIFF
--- a/src/1-basics.md
+++ b/src/1-basics.md
@@ -1263,13 +1263,12 @@ The `_` is like C `default` - it's a fall-back case. If you don't provide one th
 `rustc` will consider it an error. (In C++ the best you can expect is a warning, which
 says a lot about the respective languages).
 
-Rust `match` statements can also match on ranges. Note that these ranges have
-_three_ dots and are inclusive ranges, so that the first condition would match 3.
+Rust `match` statements can also match on ranges. Note that these ranges are inclusive, so that the first condition would match 3.
 
 ```rust
     let text = match n {
-        0...3 => "small",
-        4...6 => "medium",
+        0..=3 => "small",
+        4..=6 => "medium",
         _ => "large",
      };
 ```


### PR DESCRIPTION
Small update to the range pattern in 2nd `match` example.

Came across the helpful warning:
`warning: `...` range patterns are deprecated`
`help: use `..=` for an inclusive range`

I'm running `rustc 1.50.0 (cb75ad5db 2021-02-10)`