### PR TITLE
Updated book.toml to new format

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,3 +1,7 @@
+[book]
 title = "A Gentle Introduction to Rust"
-description = "Introduction to the Rust language, standard library and ecosystem"
 author = "Steve Donovan"
+description = "Introduction to the Rust language, standard library and ecosystem"
+
+[rust]
+edition = "2018"


### PR DESCRIPTION
Content tags now under [book].

A small change so `mdbook` stops complaining when building the book.